### PR TITLE
Update ProbNumDiffEq to v0.8.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 Distributions = "0.25"
-ProbNumDiffEq = "0.7.2"
+ProbNumDiffEq = "0.8.5"
 UnPack = "1"
 julia = "1.7"
 

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -36,7 +36,7 @@ function fenrir_nll(
     prob::ODEProblem,
     data::NamedTuple{(:t, :u)},
     observation_noise_var::Real,
-    diffusion_var::Real;
+    diffusion_var::Union{Real, Vector{<:Real}};
     dt=false,
     adaptive::Bool=false,
     tstops=[],

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -160,8 +160,10 @@ function compute_nll_and_update!(x, u, H, R, m_tmp, ZERO_DATA, cache)
     xout = cache.x_tmp
     # ProbNumDiffEq.update!(xout, x, msmnt, H, KC, MC, SC)
 
-    @unpack K1, x_tmp2, m_tmp, C_DxD = cache
-    ProbNumDiffEq.update!(xout, x, msmnt, H, K1, copy(K1), C_DxD, copy(K1), cache.C_dxd)
+    @unpack K1, C_Dxd, x_tmp2, m_tmp, C_DxD, m_tmp = cache
+    K2 = C_Dxd
+    S_cache = m_tmp.Σ
+    ProbNumDiffEq.update!(xout, x, msmnt, H, K1, K2, C_DxD, S_cache, cache.C_dxd)
 
     copy!(x, xout)
     return nll

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -154,14 +154,14 @@ function compute_nll_and_update!(x, u, H, R, m_tmp, ZERO_DATA, cache)
     nll = -logpdf(msmnt, ZERO_DATA)
     # copy!(x, ProbNumDiffEq.update(x, msmnt, H))
 
-    @unpack K1, K2, x_tmp2, m_tmp = cache
+    @unpack K1, x_tmp2, m_tmp = cache
     d = length(u)
     # KC, MC, SC = view(K1, :, 1:d), x_tmp2.Σ.mat, view(m_tmp.Σ.mat, 1:d, 1:d)
     xout = cache.x_tmp
     # ProbNumDiffEq.update!(xout, x, msmnt, H, KC, MC, SC)
 
-    @unpack K1, K2, x_tmp2, m_tmp, C_DxD = cache
-    ProbNumDiffEq.update!(xout, x, msmnt, H, K1, C_DxD, cache.C_dxd)
+    @unpack K1, x_tmp2, m_tmp, C_DxD = cache
+    ProbNumDiffEq.update!(xout, x, msmnt, H, K1, copy(K1), C_DxD, copy(K1), cache.C_dxd)
 
     copy!(x, xout)
     return nll
@@ -183,7 +183,7 @@ function get_initial_diff(prob, noisy_ode_data, tsteps, proj=I)
 
     @unpack P, PI, A, Q, Ah, Qh = integ.cache
     @unpack measurement, x_filt, x_pred = integ.cache
-    @unpack K1, K2, x_tmp2, m_tmp = integ.cache
+    @unpack K1, x_tmp2, m_tmp = integ.cache
 
     m_tmp = get_lowerdim_measurement_cache(m_tmp, E)
     measurement = get_lowerdim_measurement_cache(measurement, E)

--- a/src/likelihood.jl
+++ b/src/likelihood.jl
@@ -1,6 +1,7 @@
 """
     fenrir_nll(prob::ODEProblem, data::NamedTuple{(:t, :u)}, observation_noise_var::Real,
-        diffusion_var::Real; adaptive=false, dt=false,  proj=I, order=3::Int, tstops=[])
+               diffusion_var::Uion{Real, Vector{<:Real}};
+               adaptive=false, dt=false,  proj=I, order=3::Int, tstops=[])
 
 Compute the "Fenrir" approximate negative log-likelihood (NLL) of the data.
 

--- a/test/fenrir_nll.jl
+++ b/test/fenrir_nll.jl
@@ -30,3 +30,9 @@ nll, ts, states = fenrir_nll(remake(prob, p=pwrong), data, σ², κ²)
 
 means = ProbNumDiffEq.stack([x.μ for x in states]);
 stddevs = ProbNumDiffEq.stack([sqrt.(diag(x.Σ)) for x in states]);
+
+κ² = 1e30 * ones(length(u0))
+nll, ts, states = fenrir_nll(remake(prob, p=pwrong), data, σ², κ²)
+
+means = ProbNumDiffEq.stack([x.μ for x in states]);
+stddevs = ProbNumDiffEq.stack([sqrt.(diag(x.Σ)) for x in states]);


### PR DESCRIPTION
And add support for vector-valued diffusions.