### PR TITLE
Deprecate Fenrir.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ LinearAlgebra = "1"
 ProbNumDiffEq = "0.11,0.12,0.13"
 SimpleUnPack = "1"
 Statistics = "1"
-julia = "1.7"
+julia = "1.7-1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ LinearAlgebra = "1"
 ProbNumDiffEq = "0.11,0.12,0.13"
 SimpleUnPack = "1"
 Statistics = "1"
-julia = "1.7-1.10"
+julia = "1.7 - 1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This package is deprecated and will not be maintained anymore, as the functionality of Fenrir.jl is now implemented in [ProbNumDiffEq.jl](https://github.com/nathanaelbosch/ProbNumDiffEq.jl). Just use [ProbNumDiffEq.jl](https://github.com/nathanaelbosch/ProbNumDiffEq.jl) directy.**
+
+
 # Fenrir: Physics-Enhanced Regression for IVPs
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://nathanaelbosch.github.io/Fenrir.jl/stable)

--- a/src/Fenrir.jl
+++ b/src/Fenrir.jl
@@ -10,4 +10,14 @@ using SimpleUnPack
 include("likelihood.jl")
 export fenrir_nll
 
+function __init__()
+    # Deprecation warning: This package will not be maintained in the future.
+    @warn("""\n
+        # Deprecation warning: This package will not be maintained in the future.
+        The `fenrir_nll` function implemented in this package is now implemented in
+        ProbNumDiffEq.jl, together with other data likelihood functions. So, instead of
+        using Fenrir.jl, use ProbNumDiffEq.jl.
+    """)
+end
+
 end


### PR DESCRIPTION
Fenrir.jl is now obsolete as its functionality is implemented directly in ProbNumDiffEq.jl:
https://github.com/nathanaelbosch/ProbNumDiffEq.jl/pull/287